### PR TITLE
Fix JSON key typo in DeviceRestriction settings

### DIFF
--- a/JSON/Intune/DeviceRestriction/CIS Benchmark iOS _ iPadOS_17.json
+++ b/JSON/Intune/DeviceRestriction/CIS Benchmark iOS _ iPadOS_17.json
@@ -9,7 +9,7 @@
                 "@odata.type": "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance",
                 "settingDefinitionId": "com.apple.applicationaccess_com.apple.applicationaccess",
                 "settingInstanceTemplateReference": null,
-                "gsroupSettingCollectionValue": [
+                "groupSettingCollectionValue": [
                     {
                         "settingValueTemplateReference": null,
                         "children": [


### PR DESCRIPTION
## Summary
- correct `groupSettingCollectionValue` key name in Intune device restriction JSON

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684145a50750832cbe2fee25e010e23f