### PR TITLE
Fix comment in Jamf recon script

### DIFF
--- a/Shell/CFG_INTUNE_DEVICE_RENAME_MACBOOK.sh
+++ b/Shell/CFG_INTUNE_DEVICE_RENAME_MACBOOK.sh
@@ -9,7 +9,7 @@ scutil --set ComputerName ITSMB"$serial_Number"
 scutil --set LocalHostName ITSPMB"$serial_Number"
 scutil --set HostName ITSMB"$serial_Number"
 
-#Recon computer name and user to Jamf PRo
+# Recon computer name and user to Jamf Pro
 /usr/local/bin/jamf recon
 
 exit 0


### PR DESCRIPTION
## Summary
- fix a typo in `CFG_INTUNE_DEVICE_RENAME_MACBOOK.sh`

## Testing
- `shellcheck Shell/CFG_INTUNE_DEVICE_RENAME_MACBOOK.sh`

------
https://chatgpt.com/codex/tasks/task_e_68414af2f094832c926f96c9248da655