### PR TITLE
Fix Bicep linter failures

### DIFF
--- a/Bicep/AVD-infra/Modules/scaling.bicep
+++ b/Bicep/AVD-infra/Modules/scaling.bicep
@@ -20,6 +20,7 @@ resource scalingPlan 'Microsoft.DesktopVirtualization/scalingplans@2023-09-05' =
       {
         name: 'Weekdays'
         daysOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
+        timeZone: 'W. Europe Standard Time'
         rampUpStartTime: '06:00'
         peakStartTime: '08:00'
         rampDownStartTime: '18:00'

--- a/Bicep/AVD-infra/Modules/sessionhosts.bicep
+++ b/Bicep/AVD-infra/Modules/sessionhosts.bicep
@@ -5,7 +5,6 @@ param vmAdminUsername string
 @secure()
 param vmAdminPassword string
 param subnetId string
-param hostPoolName string
 
 resource nic 'Microsoft.Network/networkInterfaces@2023-05-01' = {
   name: '${vmName}-nic'

--- a/Bicep/AVD-infra/main.bicep
+++ b/Bicep/AVD-infra/main.bicep
@@ -73,7 +73,6 @@ module session './Modules/sessionhosts.bicep' = {
     vmAdminUsername: vmAdminUsername
     vmAdminPassword: vmAdminPassword
     subnetId: network.outputs.subnetId
-    hostPoolName: avdHostPoolName
     location: location
   }
 }


### PR DESCRIPTION
## Summary
- update scaling plan with required `timeZone`
- remove unused `hostPoolName` parameter

## Testing
- `git commit -m "Fix Bicep modules"`

------
https://chatgpt.com/codex/tasks/task_e_68510b9f52b4832cb8c064fa8b19a52c