### PR TITLE
Fix scaling plan definition

### DIFF
--- a/Bicep/AVD-infra/Modules/scaling.bicep
+++ b/Bicep/AVD-infra/Modules/scaling.bicep
@@ -10,6 +10,7 @@ resource scalingPlan 'Microsoft.DesktopVirtualization/scalingplans@2023-09-05' =
   name: scalingPlanName
   location: location
   properties: {
+    timeZone: 'W. Europe Standard Time'
     hostPoolReferences: [
       {
         hostPoolArmPath: hostPool.id
@@ -20,10 +21,22 @@ resource scalingPlan 'Microsoft.DesktopVirtualization/scalingplans@2023-09-05' =
       {
         name: 'Weekdays'
         daysOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday']
-        rampUpStartTime: '06:00'
-        peakStartTime: '08:00'
-        rampDownStartTime: '18:00'
-        offPeakStartTime: '20:00'
+        rampUpStartTime: {
+          hour: 6
+          minute: 0
+        }
+        peakStartTime: {
+          hour: 8
+          minute: 0
+        }
+        rampDownStartTime: {
+          hour: 18
+          minute: 0
+        }
+        offPeakStartTime: {
+          hour: 20
+          minute: 0
+        }
       }
     ]
   }

--- a/Bicep/AVD-infra/Modules/sessionhosts.bicep
+++ b/Bicep/AVD-infra/Modules/sessionhosts.bicep
@@ -5,7 +5,6 @@ param vmAdminUsername string
 @secure()
 param vmAdminPassword string
 param subnetId string
-param hostPoolName string
 
 resource nic 'Microsoft.Network/networkInterfaces@2023-05-01' = {
   name: '${vmName}-nic'

--- a/Bicep/AVD-infra/main.bicep
+++ b/Bicep/AVD-infra/main.bicep
@@ -73,7 +73,6 @@ module session './Modules/sessionhosts.bicep' = {
     vmAdminUsername: vmAdminUsername
     vmAdminPassword: vmAdminPassword
     subnetId: network.outputs.subnetId
-    hostPoolName: avdHostPoolName
     location: location
   }
 }


### PR DESCRIPTION
## Summary
- fix schedule start time properties to use hour/minute objects

## Testing
- `bicep build main.bicep`
- `bicep lint main.bicep`


------
https://chatgpt.com/codex/tasks/task_e_68510b9f52b4832cb8c064fa8b19a52c